### PR TITLE
Add destroy server group ops and other minor bug fixes

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CompositeExecutionInstrumentation.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CompositeExecutionInstrumentation.java
@@ -33,9 +33,9 @@ public class CompositeExecutionInstrumentation implements ExecutionInstrumentati
     }
 
     @Override
-    public void executionCompleted(Agent agent) {
+    public void executionCompleted(Agent agent, long elapsedMs) {
         for (ExecutionInstrumentation exec : instrumentations) {
-            exec.executionCompleted(agent);
+            exec.executionCompleted(agent, elapsedMs);
         }
     }
 

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultAgentScheduler.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultAgentScheduler.java
@@ -89,8 +89,9 @@ public class DefaultAgentScheduler extends CatsModuleAware implements AgentSched
         public void run() {
             try {
                 executionInstrumentation.executionStarted(agent);
+                long startTime = System.nanoTime();
                 execution.executeAgent(agent);
-                executionInstrumentation.executionCompleted(agent);
+                executionInstrumentation.executionCompleted(agent, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
             } catch (Throwable t) {
                 executionInstrumentation.executionFailed(agent, t);
             }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/ExecutionInstrumentation.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/ExecutionInstrumentation.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.cats.agent;
 public interface ExecutionInstrumentation {
     void executionStarted(Agent agent);
 
-    void executionCompleted(Agent agent);
+    void executionCompleted(Agent agent, long elapsedMs);
 
     void executionFailed(Agent agent, Throwable cause);
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/NoopExecutionInstrumentation.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/NoopExecutionInstrumentation.java
@@ -23,7 +23,7 @@ public class NoopExecutionInstrumentation implements ExecutionInstrumentation {
     }
 
     @Override
-    public void executionCompleted(Agent agent) {
+    public void executionCompleted(Agent agent, long elapsedMs) {
         //noop
     }
 

--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/agent/CompositeExecutionInstrumentationSpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/agent/CompositeExecutionInstrumentationSpec.groovy
@@ -36,11 +36,11 @@ class CompositeExecutionInstrumentationSpec extends Specification {
         1 * e2.executionStarted(agent)
 
         when:
-        subj.executionCompleted(agent)
+        subj.executionCompleted(agent, 100)
 
         then:
-        1 * e1.executionCompleted(agent)
-        1 * e2.executionCompleted(agent)
+        1 * e1.executionCompleted(agent, 100)
+        1 * e2.executionCompleted(agent, 100)
 
         when:
         subj.executionFailed(agent, cause)

--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/agent/DefaultAgentSchedulerSpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/agent/DefaultAgentSchedulerSpec.groovy
@@ -43,7 +43,7 @@ class DefaultAgentSchedulerSpec extends Specification {
         then:
         1 * instr.executionStarted(agent)
         1 * exec.executeAgent(agent)
-        1 * instr.executionCompleted(agent)
+        1 * instr.executionCompleted(agent, _ )
         0 * _
     }
 

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -186,8 +186,9 @@ public class ClusteredAgentScheduler extends CatsModuleAware implements AgentSch
         public void execute() {
             try {
                 executionInstrumentation.executionStarted(agent);
+                long startTime = System.nanoTime();
                 agentExecution.executeAgent(agent);
-                executionInstrumentation.executionCompleted(agent);
+                executionInstrumentation.executionCompleted(agent, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
             } catch (Throwable cause) {
                 executionInstrumentation.executionFailed(agent, cause);
             }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/DefaultNodeStatusProvider.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/DefaultNodeStatusProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.redis.cluster;
+
+public class DefaultNodeStatusProvider implements NodeStatusProvider {
+  @Override
+  public boolean isNodeEnabled() {
+    return true;
+  }
+}

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/NodeStatusProvider.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/NodeStatusProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.redis.cluster;
+
+public interface NodeStatusProvider {
+  boolean isNodeEnabled();
+}

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
@@ -47,7 +47,7 @@ class ClusteredAgentSchedulerSpec extends Specification {
         }
         lockPollingScheduler = new ManualRunnableScheduler()
         agentExecutionScheduler = new ManualRunnableScheduler()
-        scheduler = new ClusteredAgentScheduler(source, new DefaultNodeIdentity(), interval, lockPollingScheduler, agentExecutionScheduler)
+        scheduler = new ClusteredAgentScheduler(source, new DefaultNodeIdentity(), interval, new DefaultNodeStatusProvider(), lockPollingScheduler, agentExecutionScheduler)
     }
 
     def 'cache run aborted if agent doesnt acquire execution token'() {

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
@@ -73,7 +73,7 @@ class ClusteredAgentSchedulerSpec extends Specification {
         1 * jedis.set(_ as String, _ as String, 'NX', 'PX', _ as Long) >> 'OK'
         1 * inst.executionStarted(agent)
         1 * exec.executeAgent(agent)
-        1 * inst.executionCompleted(agent)
+        1 * inst.executionCompleted(agent, _)
         1 * jedis.eval(_ as String, _ as List, _ as List)
         2 * jedis.close()
         0 * _

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -73,6 +73,12 @@ class AwsConfiguration {
   @Value('${aws.client.maxErrorRetry:3}')
   int maxErrorRetry
 
+  @Value('${aws.client.maxConnections:200}')
+  int maxConnections
+
+  @Value('${aws.client.maxConnectionsPerRoute:20}')
+  int maxConnectionsPerRoute
+
   @Autowired
   SpectatorMetricsCollector spectatorMetricsCollector
 
@@ -101,12 +107,12 @@ class AwsConfiguration {
       .retryCondition(instrumentedRetryCondition)
       .objectMapper(amazonObjectMapper())
       .maxErrorRetry(maxErrorRetry)
+      .maxConnections(maxConnections)
+      .maxConnectionsPerRoute(maxConnectionsPerRoute)
       .proxy(proxy)
       .eddaTimeoutConfig(eddaTimeoutConfig)
       .build()
   }
-
-
 
   @Bean
   ObjectMapper amazonObjectMapper() {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.LOAD_BALANCERS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LOAD_BALANCERS
 
 @RestController
 @RequestMapping("/aws/loadBalancers")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy
@@ -30,8 +30,8 @@ import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.IMAGES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.NAMED_IMAGES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IMAGES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.NAMED_IMAGES
 
 @Slf4j
 @RestController

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -35,7 +35,8 @@ class Keys {
     APPLICATIONS,
     HEALTH,
     ON_DEMAND,
-    RESERVATION_REPORTS
+    RESERVATION_REPORTS,
+    RESERVED_INSTANCES
 
     final String ns
 
@@ -138,5 +139,9 @@ class Keys {
 
   static String getInstanceHealthKey(String instanceId, String account, String region, String provider) {
     "${PROVIDER}:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
+  }
+
+  static String getReservedInstancesKey(String reservedInstancesId, String account, String region) {
+    "${PROVIDER}:${Namespace.RESERVED_INSTANCES}:${account}:${region}:${reservedInstancesId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -17,39 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.data
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import groovy.transform.CompileStatic
 
 @CompileStatic
 class Keys {
 
   public static final PROVIDER = "aws"
-
-  static enum Namespace {
-    IMAGES,
-    NAMED_IMAGES,
-    SERVER_GROUPS,
-    INSTANCES,
-    LAUNCH_CONFIGS,
-    LOAD_BALANCERS,
-    CLUSTERS,
-    APPLICATIONS,
-    HEALTH,
-    ON_DEMAND,
-    RESERVATION_REPORTS,
-    RESERVED_INSTANCES
-
-    final String ns
-
-    private Namespace() {
-      def parts = name().split('_')
-
-      ns = parts.tail().inject(new StringBuilder(parts.head().toLowerCase())) { val, next -> val.append(next.charAt(0)).append(next.substring(1).toLowerCase()) }
-    }
-
-    String toString() {
-      ns
-    }
-  }
 
   static Map<String, String> parse(String key) {
     def parts = key.split(':')

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProvider.groovy
@@ -24,10 +24,10 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.HealthProvidingCachingAgent
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 import java.util.regex.Pattern
 import org.springframework.beans.factory.annotation.Autowired
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 class AwsProvider extends AgentSchedulerAware implements SearchableProvider {
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
@@ -50,20 +50,21 @@ class AmazonLoadBalancerInstanceStateCachingAgent implements CachingAgent,Health
   final NetflixAmazonCredentials account
   final String region
   final ObjectMapper objectMapper
+  final ApplicationContext ctx
 
   private Cache cacheView
   final static String healthId = "aws-load-balancer-instance-health"
 
-  @Autowired
-  ApplicationContext ctx
 
   AmazonLoadBalancerInstanceStateCachingAgent(AmazonClientProvider amazonClientProvider,
                                               NetflixAmazonCredentials account, String region,
-                                              ObjectMapper objectMapper) {
+                                              ObjectMapper objectMapper,
+                                              ApplicationContext ctx) {
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.ctx = ctx
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
@@ -36,13 +36,13 @@ import com.netflix.spinnaker.clouddriver.aws.model.edda.InstanceLoadBalancers
 import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstance
 import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstanceState
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 import groovy.util.logging.Slf4j
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.LOAD_BALANCERS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LOAD_BALANCERS
 
 @Slf4j
 class AmazonLoadBalancerInstanceStateCachingAgent implements CachingAgent,HealthProvidingCachingAgent, AccountAware {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -53,7 +53,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.*
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.CacheData

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/DiscoveryCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/DiscoveryCachingAgent.groovy
@@ -33,11 +33,12 @@ import com.netflix.spinnaker.clouddriver.aws.model.discovery.DiscoveryApplicatio
 import com.netflix.spinnaker.clouddriver.aws.model.discovery.DiscoveryApplications
 import com.netflix.spinnaker.clouddriver.aws.model.discovery.DiscoveryInstance
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 import groovy.util.logging.Slf4j
 import java.util.regex.Pattern
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 
 @Slf4j
 class DiscoveryCachingAgent extends AgentSchedulerAware implements CachingAgent, HealthProvidingCachingAgent {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/EddaLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/EddaLoadBalancerCachingAgent.groovy
@@ -33,9 +33,10 @@ import com.netflix.spinnaker.clouddriver.aws.model.edda.InstanceLoadBalancers
 import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstanceState
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 import groovy.util.logging.Slf4j
 
 @Slf4j

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
@@ -33,14 +33,13 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
-import groovy.util.logging.Slf4j
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.IMAGES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.NAMED_IMAGES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IMAGES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.NAMED_IMAGES
 
 class ImageCachingAgent implements CachingAgent, AccountAware, DriftMetric {
   final Logger log = LoggerFactory.getLogger(getClass())

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.IMAGES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.SERVER_GROUPS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IMAGES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
 
 class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
   final Logger log = LoggerFactory.getLogger(getClass())

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LaunchConfigCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LaunchConfigCachingAgent.groovy
@@ -34,13 +34,12 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
-import groovy.util.logging.Slf4j
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.IMAGES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.LAUNCH_CONFIGS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IMAGES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LAUNCH_CONFIGS
 
 class LaunchConfigCachingAgent implements CachingAgent, AccountAware, DriftMetric {
   final Logger log = LoggerFactory.getLogger(getClass())

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LoadBalancerCachingAgent.groovy
@@ -45,9 +45,9 @@ import org.slf4j.LoggerFactory
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.LOAD_BALANCERS
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.ON_DEMAND
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LOAD_BALANCERS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND
 
 class LoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, DriftMetric {
   final Logger log = LoggerFactory.getLogger(getClass())

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -66,6 +66,7 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
   ])
 
   private final Scheduler scheduler
+  private final ApplicationContext ctx
   private Cache cacheView
 
 
@@ -74,13 +75,12 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
   final ObjectMapper objectMapper
   final AccountReservationDetailSerializer accountReservationDetailSerializer
 
-  @Autowired
-  ApplicationContext ctx
 
   ReservationReportCachingAgent(AmazonClientProvider amazonClientProvider,
                                 Collection<NetflixAmazonCredentials> accounts,
                                 ObjectMapper objectMapper,
-                                Scheduler scheduler) {
+                                Scheduler scheduler,
+                                ApplicationContext ctx) {
     this.amazonClientProvider = amazonClientProvider
     this.accounts = accounts
 
@@ -90,6 +90,7 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
 
     this.objectMapper = objectMapper.copy().enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).registerModule(module)
     this.scheduler = scheduler
+    this.ctx = ctx
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -17,8 +17,6 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest
-import com.amazonaws.services.ec2.model.DescribeReservedInstancesRequest
-import com.amazonaws.services.ec2.model.ReservedInstances
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
@@ -43,7 +41,6 @@ import com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
 import groovy.util.logging.Slf4j
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import rx.Observable
 import rx.Scheduler
@@ -53,8 +50,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVATION_REPORTS
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVED_INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.RESERVATION_REPORTS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.RESERVED_INSTANCES
 
 @Slf4j
 class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgent {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest
 import com.amazonaws.services.ec2.model.DescribeReservedInstancesRequest
+import com.amazonaws.services.ec2.model.ReservedInstances
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
@@ -31,50 +32,50 @@ import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
 import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
 import rx.Observable
 import rx.Scheduler
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVATION_REPORTS
+import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVED_INSTANCES
 
 @Slf4j
-class ReservationReportCachingAgent implements CachingAgent {
-  private static final Collection<AgentDataType> types = Collections.unmodifiableCollection([
+class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgent {
+  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(1)
+  private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5)
+
+  final Collection<AgentDataType> types = Collections.unmodifiableCollection([
     AUTHORITATIVE.forType(RESERVATION_REPORTS.ns)
   ])
 
   private final Scheduler scheduler
+  private Cache cacheView
 
-  @Override
-  String getProviderName() {
-    AwsProvider.PROVIDER_NAME
-  }
-
-  @Override
-  String getAgentType() {
-    "${ReservationReportCachingAgent.simpleName}"
-  }
-
-  @Override
-  Collection<AgentDataType> getProvidedDataTypes() {
-    types
-  }
 
   final AmazonClientProvider amazonClientProvider
   final Collection<NetflixAmazonCredentials> accounts
   final ObjectMapper objectMapper
   final AccountReservationDetailSerializer accountReservationDetailSerializer
+
+  @Autowired
+  ApplicationContext ctx
 
   ReservationReportCachingAgent(AmazonClientProvider amazonClientProvider,
                                 Collection<NetflixAmazonCredentials> accounts,
@@ -89,6 +90,16 @@ class ReservationReportCachingAgent implements CachingAgent {
 
     this.objectMapper = objectMapper.copy().enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).registerModule(module)
     this.scheduler = scheduler
+  }
+
+  @Override
+  long getPollIntervalMillis() {
+    return DEFAULT_POLL_INTERVAL_MILLIS
+  }
+
+  @Override
+  long getTimeoutMillis() {
+    return DEFAULT_TIMEOUT_MILLIS
   }
 
   static class MutableCacheData implements CacheData {
@@ -109,6 +120,21 @@ class ReservationReportCachingAgent implements CachingAgent {
       this.attributes.putAll(attributes);
       this.relationships.putAll(relationships);
     }
+  }
+
+  @Override
+  String getProviderName() {
+    AwsProvider.PROVIDER_NAME
+  }
+
+  @Override
+  String getAgentType() {
+    "${ReservationReportCachingAgent.simpleName}"
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    types
   }
 
   public Collection<NetflixAmazonCredentials> getAccounts() {
@@ -184,8 +210,16 @@ class ReservationReportCachingAgent implements CachingAgent {
         log.info("Fetching reservation report for ${credentials.name}:${region.name}")
 
         def amazonEC2 = amazonClientProvider.getAmazonEC2(credentials, region.name)
-        def reservedInstancesResult = amazonEC2.describeReservedInstances(new DescribeReservedInstancesRequest())
-        reservedInstancesResult.reservedInstances.findAll {
+
+        def cacheView = getCacheView()
+        def reservedInstances = cacheView.getAll(
+          RESERVED_INSTANCES.ns,
+          cacheView.filterIdentifiers(RESERVED_INSTANCES.ns, Keys.getReservedInstancesKey('*', credentials.name, region.name))
+        ).collect {
+          objectMapper.convertValue(it.attributes, ReservedInstanceDetails)
+        }
+
+        reservedInstances.findAll {
           it.state.equalsIgnoreCase("active") &&
             ["Heavy Utilization", "Partial Upfront", "All Upfront", "No Upfront"].contains(it.offeringType)
         }.each {
@@ -253,6 +287,13 @@ class ReservationReportCachingAgent implements CachingAgent {
     }
   }
 
+  private Cache getCacheView() {
+    if (!this.cacheView) {
+      this.cacheView = ctx.getBean(Cache)
+    }
+    this.cacheView
+  }
+
   static class AccountReservationDetailSerializer extends JsonSerializer<AmazonReservationReport.AccountReservationDetail> {
     ObjectMapper objectMapper = new ObjectMapper()
     boolean mergeVpcReservations
@@ -273,5 +314,14 @@ class ReservationReportCachingAgent implements CachingAgent {
 
       gen.writeObject(objectMapper.convertValue(value, Map))
     }
+  }
+
+  static class ReservedInstanceDetails {
+    String state
+    String offeringType
+    String productDescription
+    String availabilityZone
+    String instanceType
+    int instanceCount
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
@@ -102,7 +102,9 @@ class ReservedInstancesCachingAgent implements CachingAgent, CustomScheduledAgen
     def result = amazonEC2.describeReservedInstances(new DescribeReservedInstancesRequest())
     List<ReservedInstances> allReservedInstances = result.reservedInstances
 
-    Collection<CacheData> reservedInstancesData = allReservedInstances.collect { ReservedInstances reservedInstances ->
+    Collection<CacheData> reservedInstancesData = allReservedInstances
+      .findAll { it.state.equalsIgnoreCase("active") }
+      .collect { ReservedInstances reservedInstances ->
       Map<String, Object> attributes = objectMapper.convertValue(reservedInstances, ATTRIBUTES);
       new DefaultCacheData(Keys.getReservedInstancesKey(reservedInstances.reservedInstancesId, account.name, region), attributes, [:])
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.aws.provider.agent
+
+import com.amazonaws.services.ec2.model.DescribeReservedInstancesRequest
+import com.amazonaws.services.ec2.model.ReservedInstances
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.AccountAware
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.agent.CachingAgent
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.TimeUnit
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVED_INSTANCES
+
+class ReservedInstancesCachingAgent implements CachingAgent, CustomScheduledAgent, AccountAware {
+  private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
+  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(10)
+  private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5)
+
+  final Logger log = LoggerFactory.getLogger(getClass())
+
+  final Set<AgentDataType> types = Collections.unmodifiableSet([
+    AUTHORITATIVE.forType(RESERVED_INSTANCES.ns)
+  ] as Set)
+
+  final AmazonClientProvider amazonClientProvider
+  final NetflixAmazonCredentials account
+  final String region
+  final ObjectMapper objectMapper
+  final Registry registry
+
+  ReservedInstancesCachingAgent(AmazonClientProvider amazonClientProvider,
+                                NetflixAmazonCredentials account,
+                                String region,
+                                ObjectMapper objectMapper,
+                                Registry registry) {
+    this.amazonClientProvider = amazonClientProvider
+    this.account = account
+    this.region = region
+    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.registry = registry
+  }
+
+  @Override
+  String getProviderName() {
+    return AwsProvider.PROVIDER_NAME
+  }
+
+  @Override
+  String getAgentType() {
+    return "${account.name}/${region}/${ReservedInstancesCachingAgent.simpleName}"
+  }
+
+  @Override
+  String getAccountName() {
+    return account.name
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    log.info("Describing items in ${agentType}")
+
+    def amazonEC2 = amazonClientProvider.getAmazonEC2(account, region)
+
+    def result = amazonEC2.describeReservedInstances(new DescribeReservedInstancesRequest())
+    List<ReservedInstances> allReservedInstances = result.reservedInstances
+
+    Collection<CacheData> reservedInstancesData = allReservedInstances.collect { ReservedInstances reservedInstances ->
+      Map<String, Object> attributes = objectMapper.convertValue(reservedInstances, ATTRIBUTES);
+      new DefaultCacheData(Keys.getReservedInstancesKey(reservedInstances.reservedInstancesId, account.name, region), attributes, [:])
+    }
+
+    log.info("Caching ${reservedInstancesData.size()} items in ${agentType}")
+    new DefaultCacheResult((RESERVED_INSTANCES.ns): reservedInstancesData)
+  }
+
+  @Override
+  long getPollIntervalMillis() {
+    return DEFAULT_POLL_INTERVAL_MILLIS
+  }
+
+  @Override
+  long getTimeoutMillis() {
+    return DEFAULT_TIMEOUT_MILLIS
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservedInstancesCachingAgent.groovy
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVED_INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.RESERVED_INSTANCES
 
 class ReservedInstancesCachingAgent implements CachingAgent, CustomScheduledAgent, AccountAware {
   private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
@@ -133,6 +134,8 @@ class AwsProviderConfig {
           newlyAddedAgents << new ImageCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry, publicRegions.add(region.name))
           newlyAddedAgents << new InstanceCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new LoadBalancerCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, objectMapper, registry)
+          newlyAddedAgents << new ReservedInstancesCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
+
           if (credentials.eddaEnabled) {
             newlyAddedAgents << new EddaLoadBalancerCachingAgent(eddaApiFactory.createApi(credentials.edda, region.name), credentials, region.name, objectMapper)
           } else {
@@ -159,7 +162,11 @@ class AwsProviderConfig {
                                                 objectMapper)
     } else {
       // This caching agent runs across all accounts in one iteration (to maintain consistency).
-      newlyAddedAgents << new ReservationReportCachingAgent(amazonClientProvider, allAccounts, objectMapper, reservationReportScheduler)
+      def reservationReportCachingAgent = new ReservationReportCachingAgent(
+        amazonClientProvider, allAccounts, objectMapper, reservationReportScheduler
+      )
+      ctx.autowireCapableBeanFactory.autowireBean(reservationReportCachingAgent)
+      newlyAddedAgents << reservationReportCachingAgent
 
       discoveryAccounts.each { disco, actMap ->
         actMap.each { region, accounts ->

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -139,9 +139,9 @@ class AwsProviderConfig {
           if (credentials.eddaEnabled) {
             newlyAddedAgents << new EddaLoadBalancerCachingAgent(eddaApiFactory.createApi(credentials.edda, region.name), credentials, region.name, objectMapper)
           } else {
-            def agent = new AmazonLoadBalancerInstanceStateCachingAgent(amazonClientProvider, credentials, region.name, objectMapper)
-            ctx.autowireCapableBeanFactory.autowireBean(agent)
-            newlyAddedAgents << agent
+            newlyAddedAgents << new AmazonLoadBalancerInstanceStateCachingAgent(
+              amazonClientProvider, credentials, region.name, objectMapper, ctx
+            )
           }
         }
 
@@ -162,11 +162,9 @@ class AwsProviderConfig {
                                                 objectMapper)
     } else {
       // This caching agent runs across all accounts in one iteration (to maintain consistency).
-      def reservationReportCachingAgent = new ReservationReportCachingAgent(
-        amazonClientProvider, allAccounts, objectMapper, reservationReportScheduler
+      newlyAddedAgents << new ReservationReportCachingAgent(
+        amazonClientProvider, allAccounts, objectMapper, reservationReportScheduler, ctx
       )
-      ctx.autowireCapableBeanFactory.autowireBean(reservationReportCachingAgent)
-      newlyAddedAgents << reservationReportCachingAgent
 
       discoveryAccounts.each { disco, actMap ->
         actMap.each { region, accounts ->

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonApplicationProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonApplicationProvider.groovy
@@ -29,7 +29,7 @@ import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 @Component
 class AmazonApplicationProvider implements ApplicationProvider {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -91,7 +91,7 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
     Closure<Boolean> instanceFilter = { rel ->
       return (asgInstances == null || asgInstances.contains(rel))
     }
-    serverGroup.instances = translateInstances(resolveRelationshipData(serverGroupData, INSTANCES.ns, instanceFilter)).values()
+    serverGroup.instances = translateInstances(resolveRelationshipData(serverGroupData, INSTANCES.ns, instanceFilter, RelationshipCacheFilter.none())).values()
 
     serverGroup
   }
@@ -269,9 +269,9 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
     resolveRelationshipData(source, relationship) { true }
   }
 
-  private Collection<CacheData> resolveRelationshipData(CacheData source, String relationship, Closure<Boolean> relFilter) {
+  private Collection<CacheData> resolveRelationshipData(CacheData source, String relationship, Closure<Boolean> relFilter, CacheFilter cacheFilter = null) {
     Collection<String> filteredRelationships = source.relationships[relationship]?.findAll(relFilter)
-    filteredRelationships ? cacheView.getAll(relationship, filteredRelationships) : []
+    filteredRelationships ? cacheView.getAll(relationship, filteredRelationships, cacheFilter) : []
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 @Component
 class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
@@ -28,8 +28,8 @@ import com.netflix.spinnaker.clouddriver.aws.model.AmazonInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 
 @Component
 class AmazonInstanceProvider implements InstanceProvider<AmazonInstance> {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -31,7 +31,7 @@ import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 @Component
 class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalancer> {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonReservationReportProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonReservationReportProvider.groovy
@@ -20,11 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.clouddriver.model.ReservationReport
 import com.netflix.spinnaker.clouddriver.model.ReservationReportProvider
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVATION_REPORTS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.RESERVATION_REPORTS
 
 @Component
 class AmazonReservationReportProvider implements ReservationReportProvider {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/data/KeysSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/data/KeysSpec.groovy
@@ -18,36 +18,37 @@ package com.netflix.spinnaker.clouddriver.data.aws
 
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import spock.lang.Specification
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import spock.lang.Unroll
 
 class KeysSpec extends Specification {
 
   @Unroll
-  def 'namespace string generation'(Keys.Namespace ns, String expected) {
+  def 'namespace string generation'(Namespace ns, String expected) {
     expect:
     ns.toString() == expected
 
     where:
-    ns                                    | expected
-    Keys.Namespace.APPLICATIONS           | "applications"
-    Keys.Namespace.LAUNCH_CONFIGS         | "launchConfigs"
+    ns                       | expected
+    Namespace.APPLICATIONS   | "applications"
+    Namespace.LAUNCH_CONFIGS | "launchConfigs"
   }
 
   def 'key parsing'() {
     expect:
-    Keys.parse(Keys.getApplicationKey('theApp')) == [provider: 'aws', type: Keys.Namespace.APPLICATIONS.ns, application: 'theapp']
-    Keys.parse(Keys.getServerGroupKey('theAsg', 'account', 'region')) == [provider: 'aws', type: Keys.Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg', serverGroup: 'theAsg', account: 'account', region: 'region', detail: null, stack: null, sequence: null]
-    Keys.parse(Keys.getServerGroupKey('theAsg-v001', 'account', 'region')) == [provider: 'aws', type: Keys.Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg', serverGroup: 'theAsg-v001', account: 'account', region: 'region', detail: null, stack: null, sequence: '1']
-    Keys.parse(Keys.getServerGroupKey('theAsg-test-v001', 'account', 'region')) == [provider: 'aws', type: Keys.Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg-test', serverGroup: 'theAsg-test-v001', account: 'account', region: 'region', stack: 'test', detail: null, sequence: '1']
-    Keys.parse(Keys.getServerGroupKey('theAsg--details-v001', 'account', 'region')) == [provider: 'aws', type: Keys.Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg--details', serverGroup: 'theAsg--details-v001', account: 'account', region: 'region', stack: null, detail: 'details', sequence: '1']
-    Keys.parse(Keys.getClusterKey('cluster', 'application', 'account')) == [provider: 'aws', type: Keys.Namespace.CLUSTERS.ns, cluster: 'cluster', application: 'application', account: 'account', stack: null, detail: null]
-    Keys.parse(Keys.getClusterKey('cluster-test', 'application', 'account')) == [provider: 'aws', type: Keys.Namespace.CLUSTERS.ns, cluster: 'cluster-test', application: 'application', account: 'account', stack: 'test', detail: null]
-    Keys.parse(Keys.getClusterKey('cluster-test-useast1', 'application', 'account')) == [provider: 'aws', type: Keys.Namespace.CLUSTERS.ns, cluster: 'cluster-test-useast1', application: 'application', account: 'account', stack: 'test', detail: 'useast1']
-    Keys.parse(Keys.getImageKey('image', 'account', 'region')) == [provider: 'aws', type: Keys.Namespace.IMAGES.ns, imageId: 'image', region: 'region', account: 'account']
-    Keys.parse(Keys.getInstanceHealthKey('instanceId', 'account', 'region', 'provider')) == [provider: 'aws', type: Keys.Namespace.HEALTH.ns, instanceId: 'instanceId', account: 'account', region: 'region', provider: 'provider']
-    Keys.parse(Keys.getLaunchConfigKey('kato-main-v056-10062014221307', 'account', 'region')) == [provider: 'aws', type: Keys.Namespace.LAUNCH_CONFIGS.ns, launchConfig: 'kato-main-v056-10062014221307', region: 'region', account: 'account', application: 'kato', stack:'main']
-    Keys.parse(Keys.getLoadBalancerKey('loadBalancer', 'account', 'region', 'vpc-12345')) == [provider: 'aws', type: Keys.Namespace.LOAD_BALANCERS.ns, loadBalancer: 'loadBalancer', account: 'account', region: 'region', vpcId: 'vpc-12345', application: 'loadbalancer', stack: null, detail: null]
-    Keys.parse(Keys.getLoadBalancerKey('kato-main-frontend', 'account', 'region', null)) == [provider: 'aws', type: Keys.Namespace.LOAD_BALANCERS.ns, loadBalancer: 'kato-main-frontend', account: 'account', region: 'region', vpcId: null, stack: 'main', detail: 'frontend', application: 'kato']
+    Keys.parse(Keys.getApplicationKey('theApp')) == [provider: 'aws', type: Namespace.APPLICATIONS.ns, application: 'theapp']
+    Keys.parse(Keys.getServerGroupKey('theAsg', 'account', 'region')) == [provider: 'aws', type: Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg', serverGroup: 'theAsg', account: 'account', region: 'region', detail: null, stack: null, sequence: null]
+    Keys.parse(Keys.getServerGroupKey('theAsg-v001', 'account', 'region')) == [provider: 'aws', type: Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg', serverGroup: 'theAsg-v001', account: 'account', region: 'region', detail: null, stack: null, sequence: '1']
+    Keys.parse(Keys.getServerGroupKey('theAsg-test-v001', 'account', 'region')) == [provider: 'aws', type: Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg-test', serverGroup: 'theAsg-test-v001', account: 'account', region: 'region', stack: 'test', detail: null, sequence: '1']
+    Keys.parse(Keys.getServerGroupKey('theAsg--details-v001', 'account', 'region')) == [provider: 'aws', type: Namespace.SERVER_GROUPS.ns, application: 'theasg', cluster: 'theAsg--details', serverGroup: 'theAsg--details-v001', account: 'account', region: 'region', stack: null, detail: 'details', sequence: '1']
+    Keys.parse(Keys.getClusterKey('cluster', 'application', 'account')) == [provider: 'aws', type: Namespace.CLUSTERS.ns, cluster: 'cluster', application: 'application', account: 'account', stack: null, detail: null]
+    Keys.parse(Keys.getClusterKey('cluster-test', 'application', 'account')) == [provider: 'aws', type: Namespace.CLUSTERS.ns, cluster: 'cluster-test', application: 'application', account: 'account', stack: 'test', detail: null]
+    Keys.parse(Keys.getClusterKey('cluster-test-useast1', 'application', 'account')) == [provider: 'aws', type: Namespace.CLUSTERS.ns, cluster: 'cluster-test-useast1', application: 'application', account: 'account', stack: 'test', detail: 'useast1']
+    Keys.parse(Keys.getImageKey('image', 'account', 'region')) == [provider: 'aws', type: Namespace.IMAGES.ns, imageId: 'image', region: 'region', account: 'account']
+    Keys.parse(Keys.getInstanceHealthKey('instanceId', 'account', 'region', 'provider')) == [provider: 'aws', type: Namespace.HEALTH.ns, instanceId: 'instanceId', account: 'account', region: 'region', provider: 'provider']
+    Keys.parse(Keys.getLaunchConfigKey('kato-main-v056-10062014221307', 'account', 'region')) == [provider: 'aws', type: Namespace.LAUNCH_CONFIGS.ns, launchConfig: 'kato-main-v056-10062014221307', region: 'region', account: 'account', application: 'kato', stack: 'main']
+    Keys.parse(Keys.getLoadBalancerKey('loadBalancer', 'account', 'region', 'vpc-12345')) == [provider: 'aws', type: Namespace.LOAD_BALANCERS.ns, loadBalancer: 'loadBalancer', account: 'account', region: 'region', vpcId: 'vpc-12345', application: 'loadbalancer', stack: null, detail: null]
+    Keys.parse(Keys.getLoadBalancerKey('kato-main-frontend', 'account', 'region', null)) == [provider: 'aws', type: Namespace.LOAD_BALANCERS.ns, loadBalancer: 'kato-main-frontend', account: 'account', region: 'region', vpcId: null, stack: 'main', detail: 'frontend', application: 'kato']
   }
 
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
@@ -16,14 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.aws.provider
 
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
@@ -117,4 +117,9 @@ public abstract class AzureBaseClient {
 
     result
   }
+
+  static Boolean resourceNotFound(int responseStatusCode) {
+    responseStatusCode == HttpURLConnection.HTTP_NO_CONTENT || responseStatusCode == HttpURLConnection.HTTP_NOT_FOUND
+  }
+
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -20,7 +20,9 @@ import com.microsoft.azure.CloudException
 import com.microsoft.azure.credentials.ApplicationTokenCredentials
 import com.microsoft.azure.management.compute.ComputeManagementClient
 import com.microsoft.azure.management.compute.ComputeManagementClientImpl
+import com.microsoft.azure.management.compute.VirtualMachineScaleSetsOperations
 import com.microsoft.azure.management.compute.models.VirtualMachineScaleSet
+import com.microsoft.rest.ServiceResponse
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureInstance
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureVMImage
@@ -152,6 +154,20 @@ public class AzureComputeClient extends AzureBaseClient {
       log.warn("ServerGroup: ${e.message} (${serverGroupName} was not found)")
     }
     null
+  }
+
+  ServiceResponse<Void> destroyServerGroup(String resourceGroupName, String serverGroupName) {
+    VirtualMachineScaleSetsOperations ops = getAzureOps(
+      client.&getVirtualMachineScaleSetsOperations, "Get operations object", "Failed to get operation object") as VirtualMachineScaleSetsOperations
+
+    deleteAzureResource(
+      ops.&delete,
+      resourceGroupName,
+      serverGroupName,
+      null,
+      "Delete Server Group ${serverGroupName}",
+      "Failed to delete Server Group ${serverGroupName} in ${resourceGroupName}"
+    )
   }
 
   Collection<AzureInstance> getServerGroupInstances(String resourceGroupName, String serverGroupName) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -150,8 +150,12 @@ public class AzureComputeClient extends AzureBaseClient {
       sg.lastReadTime = System.currentTimeMillis()
       return sg
     } catch (CloudException e) {
-      // treat exception as a http 404 return (resource not found)
-      log.warn("ServerGroup: ${e.message} (${serverGroupName} was not found)")
+      if (resourceNotFound(e.response.code())) {
+        log.warn("ServerGroup: ${e.message} (${serverGroupName} was not found)")
+      }
+      else {
+        throw e
+      }
     }
     null
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -62,12 +62,13 @@ class AzureResourceManagerClient extends AzureBaseClient {
                                                 String resourceGroupName,
                                                 String region,
                                                 String resourceName,
+                                                String resourceType,
                                                 Map<String, String> templateParams = [:]) {
 
     // TODO validate that all callers invoke this themselves, then remove this call
     initializeResourceGroupAndVNet(credentials, resourceGroupName, null, region)
 
-    String deploymentName = resourceName + AzureUtilities.NAME_SEPARATOR +"deployment"
+    String deploymentName = [resourceName, resourceType, "deployment"].join(AzureUtilities.NAME_SEPARATOR)
     if (!templateParams['location']) {
       templateParams['location'] = region
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureStorageClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureStorageClient.groovy
@@ -16,20 +16,66 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
+import com.microsoft.azure.credentials.ApplicationTokenCredentials
+import com.microsoft.azure.management.storage.StorageAccountsOperations
+import com.microsoft.azure.management.storage.StorageManagementClient
+import com.microsoft.azure.management.storage.StorageManagementClientImpl
 import com.microsoft.azure.storage.blob.CloudBlobClient
 import com.microsoft.azure.storage.blob.CloudBlobContainer
 import com.microsoft.azure.storage.blob.CloudBlobDirectory
 import com.microsoft.azure.storage.blob.ListBlobItem
 import com.microsoft.azure.storage.CloudStorageAccount
+import com.microsoft.rest.ServiceResponse
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureCustomImageStorage
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureCustomVMImage
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import okhttp3.logging.HttpLoggingInterceptor
 
 @Slf4j
 @CompileStatic
-class AzureStorageClient {
+class AzureStorageClient extends AzureBaseClient {
   static final String AZURE_IMAGE_FILE_EXT = ".vhd"
+
+  private final StorageManagementClient client
+
+  AzureStorageClient(String subscriptionId, ApplicationTokenCredentials credentials) {
+    super(subscriptionId)
+    this.client = this.initialize(credentials)
+  }
+
+  /**
+   * get the StorageManagementClient which will be used for all interaction related to compute resources in Azure
+   * @param creds the credentials to use when communicating to the Azure subscription(s)
+   * @return an instance of the Azure StorageManagementClient
+   */
+  private StorageManagementClient initialize(ApplicationTokenCredentials tokenCredentials) {
+    StorageManagementClient storageClient = new StorageManagementClientImpl(tokenCredentials)
+    storageClient.setSubscriptionId(this.subscriptionId)
+    storageClient.setLogLevel(HttpLoggingInterceptor.Level.NONE)
+    storageClient
+  }
+
+  /**
+   * Delete a storage account in the resource group specified
+   * @param resourceGroupName Resource Group in Azure where the storage account will exist
+   * @param storageName Name of the storage account to delete
+   * @throws RuntimeException Throws RuntimeException if operation response indicates failure
+   * @return a ServiceResponse object
+   */
+  ServiceResponse<Void> deleteStorageAccount(String resourceGroupName, String storageName) {
+    StorageAccountsOperations ops = getAzureOps(
+      client.&getStorageAccountsOperations, "Get operations object", "Failed to get operation object") as StorageAccountsOperations
+
+    deleteAzureResource(
+      ops.&delete,
+      resourceGroupName,
+      storageName,
+      null,
+      "Delete Storage Account ${storageName}",
+      "Failed to delete Storage Account ${storageName} in ${resourceGroupName}"
+    )
+  }
 
   /**
    * Return list of available .VHD files from a list of connection strings

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/view/AzureApplicationProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/view/AzureApplicationProvider.groovy
@@ -52,7 +52,7 @@ class AzureApplicationProvider implements ApplicationProvider {
 
   @Override
   AzureApplication getApplication(String name) {
-    translate(cacheView.get(Keys.Namespace.AZURE_APPLICATIONS.ns, Keys.getApplicationKey(azureCloudProvider, name)))
+    translate(cacheView.get(Keys.Namespace.AZURE_APPLICATIONS.ns, Keys.getApplicationKey(azureCloudProvider, name))) ?: new AzureApplication(name, [:], [:])
   }
 
   AzureApplication translate(CacheData cacheData) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
@@ -31,7 +31,8 @@ class Keys {
     AZURE_INSTANCES,
     AZURE_VMIMAGES,
     AZURE_CUSTOMVMIMAGES,
-    AZURE_ON_DEMAND
+    AZURE_ON_DEMAND,
+    AZURE_EVICTIONS
 
     final String ns
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
@@ -57,6 +57,7 @@ class DeleteAzureLoadBalancerAtomicOperation implements AtomicOperation<Void> {
           .networkClient
           .deleteLoadBalancer(resourceGroupName, description.loadBalancerName)
 
+        // TODO: check response to ensure operation succeeded
         task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${description.loadBalancerName} in ${region} has succeeded.")
       } catch (Exception e) {
         task.updateStatus(BASE_PHASE, "Deletion of load balancer ${description.loadBalancerName} failed: e.message")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
@@ -62,7 +62,8 @@ class UpsertAzureLoadBalancerAtomicOperation implements AtomicOperation<Map> {
         AzureLoadBalancerResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
-        description.loadBalancerName)
+        description.loadBalancerName,
+        "loadBalancer")
 
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
     } catch (CloudException ce) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/DeleteAzureSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/DeleteAzureSecurityGroupAtomicOperation.groovy
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.model.Del
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 
 class DeleteAzureSecurityGroupAtomicOperation implements AtomicOperation<Void> {
-  private static final String BASE_PHASE = "DELETE_LOAD_BALANCER"
+  private static final String BASE_PHASE = "DELETE_SECURITY_GROUP"
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()
@@ -52,20 +52,13 @@ class DeleteAzureSecurityGroupAtomicOperation implements AtomicOperation<Void> {
       try {
         String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, region)
 
-        def response = description
+        description
           .credentials
           .networkClient
           .deleteSecurityGroup(resourceGroupName, description.securityGroupName)
 
-        // Check to see if the operation succeeded
-        if (response.response.success) {
-          task.updateStatus BASE_PHASE, "Done deleting Azure network security group ${description.securityGroupName} in ${region}."
-        }
-        else {
-          task.updateStatus(BASE_PHASE,
-            String.format("Delete operation failed for security group ${description.securityGroupName}: %s", response.response.message()))
-          task.fail()
-        }
+        // TODO: check response to ensure operation succeeded
+        task.updateStatus BASE_PHASE, "Done deleting Azure network security group ${description.securityGroupName} in ${region}."
       } catch (Exception e) {
         task.updateStatus BASE_PHASE, String.format("Deletion of Azure network security group ${description.securityGroupName} failed: %s", e.message)
         throw new AtomicOperationException(

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
@@ -61,7 +61,8 @@ class UpsertAzureSecurityGroupAtomicOperation implements AtomicOperation<Map> {
         AzureSecurityGroupResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
-        description.securityGroupName)
+        description.securityGroupName,
+        "securityGroup")
 
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task,BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
     } catch (Exception e) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
@@ -22,6 +22,8 @@ class AzureInstance implements Instance, Serializable {
         case "ProvisioningState":
           if (codes[1].toLowerCase() == AzureUtilities.ProvisioningState.SUCCEEDED.toLowerCase()) {
             instance.launchTime = status.time?.millis
+          } else {
+            instance.healthState = HealthState.Failed
           }
           break
         case "PowerState":

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/DestroyAzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/DestroyAzureServerGroupDescription.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The original authors.
+ * Copyright 2016 The original authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.azure.resources.common
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
-import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
-
-class AzureResourceOpsDescription {
-  String name
-  String cloudProvider
-  String accountName
-  String appName
-  String stack
-  String detail
-  AzureCredentials credentials
-  String region
-  String user
-  Long createdTime
-  long lastReadTime
-  Map<String,String> tags = [:]
-
-  Long getCreatedTime() {
-    this.lastReadTime
-  }
+class DestroyAzureServerGroupDescription extends AzureServerGroupDescription{
+  String serverGroupName
+  List<String> regions
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+
+class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "DESTROY_SERVER_GROUP"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final DestroyAzureServerGroupDescription description
+
+  DestroyAzureServerGroupAtomicOperation(DestroyAzureServerGroupDescription description) {
+    this.description = description
+  }
+
+  /**
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "destroyServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   */
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing Destroy Azure Server Group Operation..."
+    for (region in description.regions) {
+      if (description.serverGroupName) description.name = description.serverGroupName
+      if (!description.application) description.application = description.appName ?: Names.parseName(description.name).app
+      task.updateStatus BASE_PHASE, "Destroying server group ${description.name} " + "in ${region}..."
+
+      if (!description.credentials) {
+        throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
+      }
+
+      def errList = new ArrayList<String>()
+
+      try {
+        String resourceGroupName = AzureUtilities.getResourceGroupName(description.application, region)
+        AzureServerGroupDescription serverGroupDescription = description.credentials.computeClient.getServerGroup(resourceGroupName, description.name)
+
+        if (!serverGroupDescription) {
+          task.updateStatus(BASE_PHASE, "Destroy Server Group Operation failed: could not find server group ${description.name} in ${region}")
+          errList.add("could not find server group ${description.name} in ${region}")
+        } else {
+          try {
+            description
+              .credentials
+              .computeClient
+              .destroyServerGroup(resourceGroupName, description.name)
+
+            task.updateStatus BASE_PHASE, "Done destroying Azure server group ${description.name} in ${region}."
+          } catch (Exception e) {
+            task.updateStatus(BASE_PHASE, "Deletion of server group ${description.name} failed: ${e.message}")
+            errList.add("Failed to delete server group ${description.name}: ${e.message}")
+          }
+
+          // Clean-up the storrage account, load balancer and the subnet that where attached to the server group
+          if (errList.isEmpty()) {
+
+            // Delete storage accounts if any
+            serverGroupDescription.storageAccountNames?.each { def storageAccountName ->
+              task.updateStatus(BASE_PHASE, "Deleting storage account ${storageAccountName} " + "in ${region}...")
+              try {
+                description
+                  .credentials
+                  .storageClient
+                  .deleteStorageAccount(resourceGroupName, storageAccountName)
+
+                task.updateStatus(BASE_PHASE, "Deletion of Azure storage account ${storageAccountName} in ${region} has succeeded.")
+              } catch (Exception e) {
+                task.updateStatus(BASE_PHASE, "Deletion of Azure storage account ${storageAccountName} failed: ${e.message}")
+                errList.add("Failed to delete storage account ${storageAccountName}: ${e.message}")
+              }
+            }
+
+            // Delete load balancer attached to server group
+            if (serverGroupDescription.loadBalancerName) {
+              task.updateStatus(BASE_PHASE, "Deleting load balancer ${serverGroupDescription.loadBalancerName} " + "in ${region}...")
+              try {
+                description
+                  .credentials
+                  .networkClient
+                  .deleteLoadBalancer(resourceGroupName, serverGroupDescription.loadBalancerName)
+
+                task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${serverGroupDescription.loadBalancerName} in ${region} has succeeded.")
+              } catch (Exception e) {
+                task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${serverGroupDescription.loadBalancerName} failed: ${e.message}")
+                errList.add("Failed to delete ${serverGroupDescription.loadBalancerName}: ${e.message}")
+              }
+            }
+
+            // Delete subnet attached to server group
+            if (serverGroupDescription.subnetId) {
+              String subnetName = AzureUtilities.getNameFromResourceId(serverGroupDescription.subnetId)
+              String virtualNetworkName = AzureUtilities.getVirtualNetworkName(resourceGroupName)
+              task.updateStatus(BASE_PHASE, "Deleting subnet ${subnetName} " + "in ${region}...")
+              try {
+                description
+                  .credentials
+                  .networkClient
+                  .deleteSubnet(resourceGroupName, virtualNetworkName, subnetName)
+
+                task.updateStatus(BASE_PHASE, "Deletion of subnet ${subnetName} in ${region} has succeeded.")
+              } catch (Exception e) {
+                task.updateStatus(BASE_PHASE, "Deletion of subnet ${subnetName} in ${virtualNetworkName} failed: ${e.message}")
+                errList.add("Failed to delete subnet ${subnetName} in ${virtualNetworkName}: ${e.message}")
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        task.updateStatus(BASE_PHASE, "Destroying server group ${description.name} failed: ${e.message}")
+        errList.add("Failed to destroy server group ${description.name}: ${e.message}")
+      }
+
+      if (errList.isEmpty()) {
+        task.updateStatus BASE_PHASE, "Destroy Azure Server Group Operation for ${description.name} succeeded."
+      }
+      else {
+        errList.add(" Go to Azure Portal for more info")
+        throw new AtomicOperationException(
+          error: "Failed to destroy ${description.name}",
+          errors: errList)
+      }
+    }
+
+    null
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.converters
+
+import com.netflix.spinnaker.clouddriver.azure.AzureOperation
+import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Slf4j
+@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
+@Component("destroyAzureServerGroupDescription")
+class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  DestroyAzureServerGroupAtomicOperationConverter() {
+    log.info("Constructor....DeleteAzureSecurityGroupAtomicOperationConverter")
+  }
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new DestroyAzureServerGroupAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  DestroyAzureServerGroupDescription convertDescription(Map input) {
+    AzureAtomicOperationConverterHelper.
+      convertDescription(input, this, DestroyAzureServerGroupDescription) as DestroyAzureServerGroupDescription
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DestroyAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DestroyAzureServerGroupDescriptionValidator.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.validators
+
+import com.netflix.spinnaker.clouddriver.azure.AzureOperation
+import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+
+@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
+@Component("DestroyAzureServerGroupDescriptionValidator")
+class DestroyAzureServerGroupDescriptionValidator extends
+  DescriptionValidator<DestroyAzureServerGroupDescription> {
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, DestroyAzureServerGroupDescription description, Errors errors) {
+    def helper = new StandardAzureAttributeValidator("DestroyAzureServerGroupDescription", errors)
+
+    helper.validateCredentials(description.credentials, accountCredentialsProvider)
+    helper.validateRegionList(description.regions)
+    helper.validateName(description.serverGroupName, "serverGroupName")
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentials.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentials.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.azure.client.AzureBaseClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureComputeClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureNetworkClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureResourceManagerClient
+import com.netflix.spinnaker.clouddriver.azure.client.AzureStorageClient
 
 class AzureCredentials {
 
@@ -32,6 +33,7 @@ class AzureCredentials {
   final AzureResourceManagerClient resourceManagerClient
   final AzureNetworkClient networkClient
   final AzureComputeClient computeClient
+  final AzureStorageClient storageClient
 
   AzureCredentials(String tenantId, String clientId, String appKey, String subscriptionId) {
     this.tenantId = tenantId
@@ -40,13 +42,14 @@ class AzureCredentials {
     this.subscriptionId = subscriptionId
     this.project = "AzureProject"
 
-    resourceManagerClient = new AzureResourceManagerClient(this.subscriptionId,
-      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
+    def token = AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey)
 
-    networkClient = new AzureNetworkClient(this.subscriptionId,
-      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
+    resourceManagerClient = new AzureResourceManagerClient(this.subscriptionId, token)
 
-    computeClient = new AzureComputeClient(this.subscriptionId,
-      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
+    networkClient = new AzureNetworkClient(this.subscriptionId, token)
+
+    computeClient = new AzureComputeClient(this.subscriptionId, token)
+
+    storageClient = new AzureStorageClient(this.subscriptionId, token)
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -84,10 +84,8 @@ class AzureServerGroupResourceTemplate {
     // These *Var variables are meant to help keep that reference from breaking IF the name of the actual variable
     // changes
     static transient String uniqueStorageNamesArrayVar = 'uniqueStorageNameArray'
-    static transient String newStorageAccountsSuffixVar = 'newStorageAccountSuffix'
     static transient String vhdContainerNameVar = 'vhdContainerName'
 
-    String newStorageAccountSuffix
     String vhdContainerName
     OsType osType
     String imageReference
@@ -99,7 +97,6 @@ class AzureServerGroupResourceTemplate {
      */
     ServerGroupTemplateVariables(AzureServerGroupDescription description) {
 
-      newStorageAccountSuffix = STORAGE_ACCOUNT_SUFFIX
       vhdContainerName = description.name.toLowerCase()
       osType = new OsType(description)
       imageReference = "[variables('osType')]"
@@ -112,7 +109,7 @@ class AzureServerGroupResourceTemplate {
 
   static String getUniqueStorageName(String name, long idx) {
     String noDashName = name.replaceAll("-", "").toLowerCase()
-    "[concat(uniqueString(concat(resourceGroup().id, subscription().id, '$noDashName', '$idx')), variables('$ServerGroupTemplateVariables.newStorageAccountsSuffixVar'))]"
+    "[concat(uniqueString(concat(resourceGroup().id, subscription().id, '$noDashName', '$idx')), '$STORAGE_ACCOUNT_SUFFIX')]"
   }
 
   /**

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroups.deploy.ops
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
+import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.converters.DestroyAzureServerGroupAtomicOperationConverter
+import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import org.mockito.Mock
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DestroyAzureServerGroupAtomicOperationSpec extends Specification {
+  static final ACCOUNT_NAME = "my-azure-account"
+  private static final CLOUD_PROVIDER = "azure"
+  private static final ACCOUNT_CLIENTID = "azureclientid"
+  private static final ACCOUNT_TENANTID = "azuretenantid1"
+  private static final ACCOUNT_APPKEY = "azureappkey1"
+  private static final SUBSCRIPTION_ID = "azuresubscriptionid1"
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared
+  DestroyAzureServerGroupAtomicOperationConverter converter
+
+  @Shared
+  AzureCredentials azureCredentials
+
+  @Shared
+  AzureNamedAccountCredentials credentials
+
+  @Shared
+  AccountCredentialsProvider accountCredentialsProvider
+
+  def setupSpec() {
+    converter = new DestroyAzureServerGroupAtomicOperationConverter(objectMapper: mapper)
+    azureCredentials = new AzureCredentials(ACCOUNT_CLIENTID, ACCOUNT_TENANTID, ACCOUNT_APPKEY, SUBSCRIPTION_ID)
+
+    def credentialsRepo = new MapBackedAccountCredentialsRepository()
+    credentials = Mock(AzureNamedAccountCredentials)
+    credentials.getAccountName() >> ACCOUNT_NAME
+    credentials.getName() >> ACCOUNT_NAME
+    credentials.getCredentials() >> azureCredentials
+    credentialsRepo.save(ACCOUNT_NAME, credentials)
+    accountCredentialsProvider = new DefaultAccountCredentialsProvider(credentialsRepo)
+    accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    accountCredentialsProvider.getCredentials(_) >> credentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "Create DestroyAzureServerGroupAtomicOperation object simple test"() {
+    setup:
+    def input = '''{ "serverGroupName": "testazure-web1-d1-v000", "name": "testazure-web1-d1-v000", "account" : "my-azure-account", "cloudProvider" : "azure", "appName" : "testazure", "regions": ["westus"], "credentials": "my-azure-account" }'''
+
+    when:
+    DestroyAzureServerGroupAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
+    DestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
+
+    then:
+    operation
+    description.name == "testazure-web1-d1-v000"
+    description.accountName == "my-azure-account"
+    description.regions[0] == "westus"
+  }
+
+  void "Create DestroyAzureServerGroupAtomicOperation object with no name and acccountName"() {
+    setup:
+    def input = '''{ "serverGroupName": "testazure-web1-d1-v000", "cloudProvider" : "azure", "appName" : "testazure", "regions": ["westus", "eastus"], "credentials": "my-azure-account" }'''
+
+    when:
+    DestroyAzureServerGroupAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
+    DestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
+
+    then:
+    operation
+    description.serverGroupName == "testazure-web1-d1-v000"
+    description.accountName == "my-azure-account"
+    description.regions[1] == "eastus"
+  }
+}

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -101,7 +101,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "newStorageAccountSuffix" : "sa",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -110,7 +109,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "version" : "latest"
     },
     "imageReference" : "[variables('osType')]",
-    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), variables('newStorageAccountSuffix'))]" ]
+    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]" ]
   },
   "resources" : [ {
     "apiVersion" : "2015-06-15",
@@ -143,7 +142,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "cluster" : "azureMASM-st1-d11",
       "loadBalancerName" : "azureMASM-st1-d11",
       "imageIsCustom" : "false",
-      "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), variables('newStorageAccountSuffix'))]"
+      "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
     "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/EurekaStatusNodeStatusProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/EurekaStatusNodeStatusProvider.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cache
+
+import com.netflix.appinfo.InstanceInfo
+import com.netflix.discovery.DiscoveryClient
+import com.netflix.spinnaker.cats.redis.cluster.NodeStatusProvider
+
+class EurekaStatusNodeStatusProvider implements NodeStatusProvider {
+  private final DiscoveryClient discoveryClient;
+
+  EurekaStatusNodeStatusProvider(DiscoveryClient discoveryClient) {
+    this.discoveryClient = discoveryClient
+  }
+
+  @Override
+  boolean isNodeEnabled() {
+    discoveryClient.instanceRemoteStatus == InstanceInfo.InstanceStatus.UP
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/LoggingInstrumentation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/LoggingInstrumentation.groovy
@@ -22,6 +22,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
+import java.util.concurrent.TimeUnit
+
 @Component
 class LoggingInstrumentation implements ExecutionInstrumentation {
   private final Logger logger = LoggerFactory.getLogger(LoggingInstrumentation)
@@ -33,7 +35,8 @@ class LoggingInstrumentation implements ExecutionInstrumentation {
 
   @Override
   void executionCompleted(Agent agent) {
-    logger.info("${agent.providerName}:${agent.agentType} completed")
+    def durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - MetricInstrumentation.getAgentStartTimeNs(agent))
+    logger.info("${agent.providerName}:${agent.agentType} completed in ${durationMs / 1000}s")
   }
 
   @Override

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/LoggingInstrumentation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/LoggingInstrumentation.groovy
@@ -22,8 +22,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
-import java.util.concurrent.TimeUnit
-
 @Component
 class LoggingInstrumentation implements ExecutionInstrumentation {
   private final Logger logger = LoggerFactory.getLogger(LoggingInstrumentation)
@@ -34,8 +32,7 @@ class LoggingInstrumentation implements ExecutionInstrumentation {
   }
 
   @Override
-  void executionCompleted(Agent agent) {
-    def durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - MetricInstrumentation.getAgentStartTimeNs(agent))
+  void executionCompleted(Agent agent, long durationMs) {
     logger.info("${agent.providerName}:${agent.agentType} completed in ${durationMs / 1000}s")
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/MetricInstrumentation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/MetricInstrumentation.groovy
@@ -78,5 +78,10 @@ class MetricInstrumentation implements ExecutionInstrumentation {
     timingsMap.get().remove(agentName(agent))
     registry.counter(counterId.withTag('agent', agentName(agent)).withTag('status', 'failure')).increment()
   }
+
+
+  static Long getAgentStartTimeNs(Agent agent) {
+    return timingsMap.get().get(agentName(agent))
+  }
 }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/HealthProvidingCachingAgent.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/HealthProvidingCachingAgent.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.provider.agent
+package com.netflix.spinnaker.clouddriver.core.provider.agent
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.netflix.spinnaker.cats.agent.AgentDataType
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.cats.agent.CachingAgent
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 
 interface HealthProvidingCachingAgent extends CachingAgent {
   static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.provider.agent
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+public enum Namespace {
+  IMAGES,
+  NAMED_IMAGES,
+  SERVER_GROUPS,
+  INSTANCES,
+  LAUNCH_CONFIGS,
+  LOAD_BALANCERS,
+  CLUSTERS,
+  APPLICATIONS,
+  HEALTH,
+  ON_DEMAND,
+  RESERVATION_REPORTS,
+  RESERVED_INSTANCES
+
+  final String ns
+
+  private Namespace() {
+    def parts = name().split('_')
+
+    ns = parts.tail().inject(new StringBuilder(parts.head().toLowerCase())) { val, next -> val.append(next.charAt(0)).append(next.substring(1).toLowerCase()) }
+  }
+
+  String toString() {
+    ns
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
@@ -49,4 +49,7 @@ final class AtomicOperations {
   // Security Group operations
   public static final String DELETE_SECURITY_GROUP = "deleteSecurityGroup"
   public static final String UPSERT_SECURITY_GROUP = "upsertSecurityGroup"
+
+  // Job operations
+  public static final String RUN_JOB = "runJob"
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -78,10 +78,7 @@ public class DockerRegistryNamedAccountCredentials implements AccountCredentials
     this.email = email
     this.requiredGroupMembership = requiredGroupMembership == null ? Collections.emptyList() : Collections.unmodifiableList(requiredGroupMembership)
     this.credentials = buildCredentials(repositories)
-    this.repositories = this.credentials.repositories
-    if (!this.repositories) {
-      throw new DockerRegistryConfigException("No existing repositories found at for ${this.name} at ${this.address}.")
-    }
+    this.repositories = this.credentials.repositories ?: []
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -85,19 +85,19 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
 
     BatchRequest forwardingRulesRequest = buildBatchRequest()
     BatchRequest targetPoolsRequest = buildBatchRequest()
-    BatchRequest instanceHealthRequest = buildBatchRequest()
     BatchRequest httpHealthChecksRequest = buildBatchRequest()
+    BatchRequest instanceHealthRequest = buildBatchRequest()
 
     ForwardingRulesCallback callback = new ForwardingRulesCallback(loadBalancers: loadBalancers,
                                                                    targetPoolsRequest: targetPoolsRequest,
-                                                                   instanceHealthRequest: instanceHealthRequest,
-                                                                   httpHealthChecksRequest: httpHealthChecksRequest)
+                                                                   httpHealthChecksRequest: httpHealthChecksRequest,
+                                                                   instanceHealthRequest: instanceHealthRequest)
     compute.forwardingRules().list(project, region).queue(forwardingRulesRequest, callback)
 
     executeIfRequestsAreQueued(forwardingRulesRequest)
     executeIfRequestsAreQueued(targetPoolsRequest)
-    executeIfRequestsAreQueued(instanceHealthRequest)
     executeIfRequestsAreQueued(httpHealthChecksRequest)
+    executeIfRequestsAreQueued(instanceHealthRequest)
 
     return loadBalancers
   }
@@ -176,8 +176,8 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
     BatchRequest targetPoolsRequest
 
     // Pass through objects
-    BatchRequest instanceHealthRequest
     BatchRequest httpHealthChecksRequest
+    BatchRequest instanceHealthRequest
 
     @Override
     void onSuccess(ForwardingRuleList forwardingRuleList, HttpHeaders responseHeaders) throws IOException {
@@ -196,8 +196,8 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
         if (forwardingRule.target) {
           def targetPoolName = Utils.getLocalName(forwardingRule.target)
           def targetPoolsCallback = new TargetPoolCallback(googleLoadBalancer: newLoadBalancer,
-                                                           instanceHealthRequest: instanceHealthRequest,
-                                                           httpHealthChecksRequest: httpHealthChecksRequest)
+                                                           httpHealthChecksRequest: httpHealthChecksRequest,
+                                                           instanceHealthRequest: instanceHealthRequest)
 
           compute.targetPools().get(project, region, targetPoolName).queue(targetPoolsRequest, targetPoolsCallback)
         }
@@ -209,8 +209,8 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
 
     GoogleLoadBalancer2 googleLoadBalancer
 
-    BatchRequest instanceHealthRequest
     BatchRequest httpHealthChecksRequest
+    BatchRequest instanceHealthRequest
 
     @Override
     void onSuccess(TargetPool targetPool, HttpHeaders responseHeaders) throws IOException {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
@@ -308,7 +309,9 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent implement
 
   void moveOnDemandDataToNamespace(CacheResultBuilder cacheResultBuilder, GoogleServerGroup2 googleServerGroup) {
     def serverGroupKey = Keys.getServerGroupKey(googleServerGroup.name, accountName, googleServerGroup.zone)
-    Map<String, List<CacheData>> onDemandData = cacheResultBuilder.onDemand.toKeep[serverGroupKey].attributes.cacheResults
+    Map<String, List<CacheData>> onDemandData = objectMapper.readValue(
+        cacheResultBuilder.onDemand.toKeep[serverGroupKey].attributes.cacheResults,
+        new TypeReference<Map<String, List<CacheData>>>() {})
 
     onDemandData.each { String namespace, List<CacheData> cacheDatas ->
       cacheDatas.each { CacheData cacheData ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -73,7 +73,7 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
 
       def loadBalancerServerGroup = new LoadBalancerServerGroup(
           name: serverGroup.name,
-          isDisabled: false, // Given this relationship started from a load balancer, it's inherently enabled.
+          isDisabled: serverGroup.disabled,
           detachedInstances: [],
           instances: [])
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception.KubernetesO
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.api.model.*
 import io.fabric8.kubernetes.api.model.extensions.Ingress
+import io.fabric8.kubernetes.api.model.extensions.Job
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
 
@@ -285,6 +286,22 @@ class KubernetesApiAdaptor {
       client.namespaces().create(namespace)
     } catch (KubernetesClientException e) {
       throw new KubernetesOperationException("Create Namespace", e)
+    }
+  }
+
+  Job createJob(String namespace, Job job) {
+    try {
+      client.extensions().jobs().inNamespace(namespace).create(job)
+    } catch (KubernetesClientException e) {
+      throw new KubernetesOperationException("Create Job", e)
+    }
+  }
+
+  List<Job> getJobs(String namespace) {
+    try {
+      client.extensions().jobs().inNamespace(namespace).list().items
+    } catch (KubernetesClientException e) {
+      throw new KubernetesOperationException("Get Jobs", e)
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesJobNameResolver.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesJobNameResolver.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.helpers.AbstractServerGroupNameResolver
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesModelUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import io.fabric8.kubernetes.api.model.ReplicationController
+import io.fabric8.kubernetes.api.model.extensions.Job
+
+class KubernetesJobNameResolver extends AbstractServerGroupNameResolver {
+
+  private static final String PHASE = "START_JOB"
+
+  private final String namespace
+  private final KubernetesCredentials credentials
+
+  KubernetesJobNameResolver(String namespace, KubernetesCredentials credentials) {
+    this.namespace = namespace
+    this.credentials = credentials
+  }
+
+  @Override
+  String getPhase() {
+    return PHASE
+  }
+
+  @Override
+  String getRegion() {
+    return namespace
+  }
+
+  @Override
+  List<AbstractServerGroupNameResolver.TakenSlot> getTakenSlots(String clusterName) {
+    def replicationControllers = credentials.apiAdaptor.getJobs(namespace)
+
+    return replicationControllers.findResults { Job job ->
+      def names = Names.parseName(job.metadata.name)
+
+      if (names.cluster == clusterName) {
+        return new AbstractServerGroupNameResolver.TakenSlot(
+          serverGroupName: job.metadata.name,
+          sequence       : names.sequence,
+          createdTime    : new Date(KubernetesModelUtil.translateTime(job.metadata.creationTimestamp))
+        )
+      } else {
+        return null
+      }
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesServerGroupNameResolver.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesServerGroupNameResolver.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.helpers.AbstractServerGroupNameResolver
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesModelUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import io.fabric8.kubernetes.api.model.ReplicationController
+
+class KubernetesServerGroupNameResolver extends AbstractServerGroupNameResolver {
+
+  private static final String PHASE = "DEPLOY"
+
+  private final String namespace
+  private final KubernetesCredentials credentials
+
+  KubernetesServerGroupNameResolver(String namespace, KubernetesCredentials credentials) {
+    this.namespace = namespace
+    this.credentials = credentials
+  }
+
+  @Override
+  String getPhase() {
+    return PHASE
+  }
+
+  @Override
+  String getRegion() {
+    return namespace
+  }
+
+  @Override
+  List<AbstractServerGroupNameResolver.TakenSlot> getTakenSlots(String clusterName) {
+    def replicationControllers = credentials.apiAdaptor.getReplicationControllers(namespace)
+
+    return replicationControllers.findResults { ReplicationController replicationController ->
+      def names = Names.parseName(replicationController.metadata.name)
+
+      if (names.cluster == clusterName) {
+        return new AbstractServerGroupNameResolver.TakenSlot(
+          serverGroupName: replicationController.metadata.name,
+          sequence       : names.sequence,
+          createdTime    : new Date(KubernetesModelUtil.translateTime(replicationController.metadata.creationTimestamp))
+        )
+      } else {
+        return null
+      }
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -29,6 +29,7 @@ class KubernetesUtil {
   static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
   static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
   static String REPLICATION_CONTROLLER_LABEL = "replication-controller"
+  static String JOB_LABEL = "job"
   @Value("kubernetes.defaultRegistry:gcr.io")
   static String DEFAULT_REGISTRY
   private static int SECURITY_GROUP_LABEL_PREFIX_LENGTH = SECURITY_GROUP_LABEL_PREFIX.length()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/job/RunKubernetesJobAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/job/RunKubernetesJobAtomicOperationConverter.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.job
+
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.job.KubernetesJobDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.job.RunKubernetesJobAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@KubernetesOperation(AtomicOperations.RUN_JOB)
+@Component
+class RunKubernetesJobAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  AtomicOperation convertOperation(Map input) {
+    new RunKubernetesJobAtomicOperation(convertDescription(input))
+  }
+
+  KubernetesJobDescription convertDescription(Map input) {
+    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, KubernetesJobDescription)
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/KubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/KubernetesJobDescription.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.job
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesVolumeSource
+import groovy.transform.AutoClone
+import groovy.transform.Canonical
+
+@AutoClone
+@Canonical
+class KubernetesJobDescription extends KubernetesAtomicOperationDescription {
+  String application
+  String stack
+  String freeFormDetails
+  String namespace
+  Integer parallelism
+  Integer completions
+  List<String> loadBalancers
+  List<KubernetesContainerDescription> containers
+  List<KubernetesVolumeSource> volumeSources
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.job
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiConverter
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesJobNameResolver
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.job.KubernetesJobDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import io.fabric8.kubernetes.api.model.extensions.Job
+import io.fabric8.kubernetes.api.model.extensions.JobBuilder
+
+class RunKubernetesJobAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "RUN_JOB"
+
+  RunKubernetesJobAtomicOperation(KubernetesJobDescription description) {
+    this.description = description
+  }
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  KubernetesJobDescription description
+
+  /*
+   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "runJob": { "application": "kub", "stack": "test",  "parallelism": 1, "completions": 1, "loadBalancers":  [],  "containers": [ { "name": "librarynginx", "imageDescription": { "repository": "library/nginx" } } ], "account":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+  */
+  @Override
+  Void operate(List priorOutputs) {
+    jobDescription()
+    return
+  }
+
+  Job jobDescription() {
+    task.updateStatus BASE_PHASE, "Initializing creation of job..."
+    task.updateStatus BASE_PHASE, "Looking up provided namespace..."
+
+    def credentials = description.credentials
+    def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
+
+    def jobNameResolver = new KubernetesJobNameResolver(namespace, credentials)
+    def clusterName = jobNameResolver.combineAppStackDetail(description.application, description.stack, description.freeFormDetails)
+
+    task.updateStatus BASE_PHASE, "Looking up next sequence index for cluster ${clusterName}..."
+    def jobName = jobNameResolver.resolveNextServerGroupName(description.application, description.stack, description.freeFormDetails, false)
+    task.updateStatus BASE_PHASE, "Job name chosen to be ${jobName}."
+
+    def jobBuilder = new JobBuilder().withNewMetadata().withName(jobName).endMetadata()
+
+    jobBuilder = jobBuilder.withNewSpec().withNewSelector().withMatchLabels([(KubernetesUtil.JOB_LABEL): jobName]).endSelector()
+
+    task.updateStatus BASE_PHASE, "Setting completions and parallelism..."
+
+    jobBuilder = jobBuilder.withParallelism(description.parallelism).withCompletions(description.completions)
+        .withNewTemplate()
+        .withNewMetadata()
+
+    task.updateStatus BASE_PHASE, "Setting job spec labels..."
+
+    jobBuilder = jobBuilder.addToLabels(KubernetesUtil.JOB_LABEL, jobName)
+
+    for (def loadBalancer : description.loadBalancers) {
+      jobBuilder = jobBuilder.addToLabels(KubernetesUtil.loadBalancerKey(loadBalancer), "true")
+    }
+
+    jobBuilder = jobBuilder.endMetadata().withNewSpec()
+
+    jobBuilder = jobBuilder.withRestartPolicy("OnFailure")
+
+    task.updateStatus BASE_PHASE, "Adding image pull secrets... "
+    jobBuilder = jobBuilder.withImagePullSecrets()
+
+    for (def imagePullSecret : credentials.imagePullSecrets[namespace]) {
+      jobBuilder = jobBuilder.addNewImagePullSecret(imagePullSecret)
+    }
+
+
+    if (description.volumeSources) {
+      def volumeSources = description.volumeSources.findResults { volumeSource ->
+        KubernetesApiConverter.toVolumeSource(volumeSource)
+      }
+
+      jobBuilder = jobBuilder.withVolumes(volumeSources)
+    }
+
+    def containers = description.containers.collect { container ->
+      KubernetesApiConverter.toContainer(container)
+    }
+
+    jobBuilder = jobBuilder.withContainers(containers)
+
+    jobBuilder = jobBuilder.endSpec().endTemplate().endSpec()
+
+    task.updateStatus BASE_PHASE, "Sending job spec to the Kubernetes master."
+    Job job = credentials.apiAdaptor.createJob(namespace, jobBuilder.build())
+
+    task.updateStatus BASE_PHASE, "Finished creating job ${job.metadata.name}."
+
+    return job
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiConverter
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesServerGroupNameResolver
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesHandlerType
@@ -63,11 +65,11 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
     def credentials = description.credentials
     def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
 
-    def clusterName = KubernetesUtil.combineAppStackDetail(description.application, description.stack, description.freeFormDetails)
-    task.updateStatus BASE_PHASE, "Looking up next sequence index..."
-    def sequenceIndex = KubernetesUtil.getNextSequence(clusterName, namespace, credentials)
-    task.updateStatus BASE_PHASE, "Sequence index chosen to be ${sequenceIndex}."
-    def replicationControllerName = String.format("%s-v%s", clusterName, sequenceIndex)
+    def serverGroupNameResolver = new KubernetesServerGroupNameResolver(namespace, credentials)
+    def clusterName = serverGroupNameResolver.combineAppStackDetail(description.application, description.stack, description.freeFormDetails)
+
+    task.updateStatus BASE_PHASE, "Looking up next sequence index for cluster ${clusterName}..."
+    def replicationControllerName = serverGroupNameResolver.resolveNextServerGroupName(description.application, description.stack, description.freeFormDetails, false)
     task.updateStatus BASE_PHASE, "Replication controller name chosen to be ${replicationControllerName}."
 
     def replicationControllerBuilder = new ReplicationControllerBuilder().withNewMetadata().withName(replicationControllerName).endMetadata()
@@ -102,239 +104,18 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
     }
 
     if (description.volumeSources) {
-      task.updateStatus BASE_PHASE, "Adding pod volume sources... "
       def volumeSources = description.volumeSources.findResults { volumeSource ->
-        Volume volume = new Volume(name: volumeSource.name)
-
-        switch (volumeSource.type) {
-          case KubernetesVolumeSourceType.EMPTYDIR:
-            def res = new EmptyDirVolumeSourceBuilder()
-
-            switch (volumeSource.emptyDir.medium) {
-              case KubernetesStorageMediumType.MEMORY:
-                res = res.withMedium("Memory")
-                break
-
-              default:
-                res = res.withMedium("") // Empty string is default...
-            }
-
-            volume.emptyDir = res.build()
-            break
-
-          case KubernetesVolumeSourceType.HOSTPATH:
-            def res = new HostPathVolumeSourceBuilder().withPath(volume.hostPath.path)
-            volume.hostPath = res.build()
-            break
-
-          case KubernetesVolumeSourceType.PERSISTENTVOLUMECLAIM:
-            def res = new PersistentVolumeClaimVolumeSourceBuilder()
-                .withClaimName(volumeSource.persistentVolumeClaim.claimName)
-                .withReadOnly(volumeSource.persistentVolumeClaim.readOnly)
-            volume.persistentVolumeClaim = res.build()
-            break
-
-          case KubernetesVolumeSourceType.SECRET:
-            def res = new SecretVolumeSourceBuilder()
-                .withSecretName(volumeSource.secret.secretName)
-            volume.secret = res.build()
-            break
-
-          default:
-            return null
-        }
-
-        return volume
+        KubernetesApiConverter.toVolumeSource(volumeSource)
       }
 
       replicationControllerBuilder = replicationControllerBuilder.withVolumes(volumeSources)
     }
 
-    for (def container : description.containers) {
-      KubernetesUtil.normalizeImageDescription(container.imageDescription)
-      def imageId = KubernetesUtil.getImageId(container.imageDescription)
-      task.updateStatus BASE_PHASE, "Adding container ${container.name} with image ${imageId}..."
-      replicationControllerBuilder = replicationControllerBuilder.addNewContainer().withName(container.name).withImage(imageId)
-
-      if (container.ports) {
-        task.updateStatus BASE_PHASE, "Setting container ports..."
-
-        container.ports.forEach {
-          replicationControllerBuilder = replicationControllerBuilder.addNewPort()
-          if (it.name) {
-            replicationControllerBuilder = replicationControllerBuilder.withName(it.name)
-          }
-
-          if (it.containerPort) {
-            replicationControllerBuilder = replicationControllerBuilder.withContainerPort(it.containerPort)
-          }
-
-          if (it.hostPort) {
-            replicationControllerBuilder = replicationControllerBuilder.withHostPort(it.hostPort)
-          }
-
-          if (it.protocol) {
-            replicationControllerBuilder = replicationControllerBuilder.withProtocol(it.protocol)
-          }
-
-          if (it.hostIp) {
-            replicationControllerBuilder = replicationControllerBuilder.withHostIP(it.hostIp)
-          }
-          replicationControllerBuilder = replicationControllerBuilder.endPort()
-        }
-      }
-
-      [liveness: container.livenessProbe, readiness: container.readinessProbe].each { k, v ->
-        def probe = v
-        if (probe) {
-          switch (k) {
-            case 'liveness':
-              task.updateStatus BASE_PHASE, 'Adding liveness probe...'
-              replicationControllerBuilder = replicationControllerBuilder.withNewLivenessProbe()
-              break
-            case 'readiness':
-              task.updateStatus BASE_PHASE, 'Adding readiness probe...'
-              replicationControllerBuilder = replicationControllerBuilder.withNewReadinessProbe()
-              break
-          }
-
-          replicationControllerBuilder = replicationControllerBuilder.withInitialDelaySeconds(probe.initialDelaySeconds)
-
-          if (probe.timeoutSeconds) {
-            replicationControllerBuilder = replicationControllerBuilder.withTimeoutSeconds(probe.timeoutSeconds)
-          }
-
-          if (probe.failureThreshold) {
-            replicationControllerBuilder = replicationControllerBuilder.withFailureThreshold(probe.failureThreshold)
-          }
-
-          if (probe.successThreshold) {
-            replicationControllerBuilder = replicationControllerBuilder.withSuccessThreshold(probe.successThreshold)
-          }
-
-          if (probe.periodSeconds) {
-            replicationControllerBuilder = replicationControllerBuilder.withPeriodSeconds(probe.periodSeconds)
-          }
-
-          task.updateStatus BASE_PHASE, 'Adding probe handler..'
-          switch (probe.handler.type) {
-            case KubernetesHandlerType.EXEC:
-              replicationControllerBuilder = replicationControllerBuilder.withNewExec().withCommand(probe.handler.execAction.commands).endExec()
-              break
-
-            case KubernetesHandlerType.TCP:
-              replicationControllerBuilder = replicationControllerBuilder.withNewTcpSocket().withNewPort(probe.handler.tcpSocketAction.port).endTcpSocket()
-              break
-
-            case KubernetesHandlerType.HTTP:
-              replicationControllerBuilder = replicationControllerBuilder.withNewHttpGet()
-              def get = probe.handler.httpGetAction
-
-              if (get.host) {
-                replicationControllerBuilder = replicationControllerBuilder.withHost(get.host)
-              }
-
-              if (get.path) {
-                replicationControllerBuilder = replicationControllerBuilder.withPath(get.path)
-              }
-
-              replicationControllerBuilder = replicationControllerBuilder.withPort(new IntOrString(get.port))
-
-              if (get.uriScheme) {
-                replicationControllerBuilder = replicationControllerBuilder.withScheme(get.uriScheme)
-              }
-
-              replicationControllerBuilder = replicationControllerBuilder.endHttpGet()
-              break
-          }
-
-          switch (k) {
-            case 'liveness':
-              replicationControllerBuilder = replicationControllerBuilder.endLivenessProbe()
-              break
-            case 'readiness':
-              replicationControllerBuilder = replicationControllerBuilder.endReadinessProbe()
-              break
-          }
-        }
-      }
-
-      replicationControllerBuilder = replicationControllerBuilder.withNewResources()
-      if (container.requests) {
-        def requests = [:]
-
-        if (container.requests.memory) {
-          requests.memory = container.requests.memory
-        }
-
-        if (container.requests.cpu) {
-          requests.cpu = container.requests.cpu
-        }
-        task.updateStatus BASE_PHASE, "Setting resource requests..."
-        replicationControllerBuilder = replicationControllerBuilder.withRequests(requests)
-      }
-
-      if (container.limits) {
-        def limits = [:]
-
-        if (container.limits.memory) {
-          limits.memory = container.limits.memory
-        }
-
-        if (container.limits.cpu) {
-          limits.cpu = container.limits.cpu
-        }
-
-        task.updateStatus BASE_PHASE, "Setting resource limits..."
-        replicationControllerBuilder = replicationControllerBuilder.withLimits(limits)
-      }
-
-      replicationControllerBuilder = replicationControllerBuilder.endResources()
-
-      if (container.volumeMounts) {
-        task.updateStatus BASE_PHASE, "Adding container volume mounts..."
-
-        def volumeMounts = container.volumeMounts.collect { mount ->
-          def res = new VolumeMountBuilder()
-
-          return res.withMountPath(mount.mountPath)
-              .withName(mount.name)
-              .withReadOnly(mount.readOnly)
-              .build()
-        }
-
-        replicationControllerBuilder = replicationControllerBuilder.withVolumeMounts(volumeMounts)
-      }
-
-      if (container.envVars) {
-        task.updateStatus BASE_PHASE, "Setting container env vars..."
-
-        def envVars = container.envVars.collect { envVar ->
-          def res = new EnvVarBuilder()
-
-          return res.withName(envVar.name)
-              .withValue(envVar.value)
-              .build()
-        }
-
-        replicationControllerBuilder = replicationControllerBuilder.withEnv(envVars)
-      }
-
-      if (container.command) {
-        task.updateStatus BASE_PHASE, "Setting container command..."
-
-        replicationControllerBuilder = replicationControllerBuilder.withCommand(container.command)
-      }
-
-      if (container.args) {
-        task.updateStatus BASE_PHASE, "Setting container args..."
-
-        replicationControllerBuilder = replicationControllerBuilder.withArgs(container.args)
-      }
-
-      replicationControllerBuilder = replicationControllerBuilder.endContainer()
-      task.updateStatus BASE_PHASE, "Finished adding container ${container.name}."
+    def containers = description.containers.collect { container ->
+      KubernetesApiConverter.toContainer(container)
     }
+
+    replicationControllerBuilder = replicationControllerBuilder.withContainers(containers)
 
     replicationControllerBuilder = replicationControllerBuilder.endSpec().endTemplate().endSpec()
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -101,7 +101,6 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
       replicationControllerBuilder = replicationControllerBuilder.addNewImagePullSecret(imagePullSecret)
     }
 
-
     if (description.volumeSources) {
       task.updateStatus BASE_PHASE, "Adding pod volume sources... "
       def volumeSources = description.volumeSources.findResults { volumeSource ->

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/KubernetesContainerValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/KubernetesContainerValidator.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesHandlerType

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/KubernetesVolumeSourceValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/KubernetesVolumeSourceValidator.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesHandlerType
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesProbe
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesVolumeSource
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesVolumeSourceType
+
+class KubernetesVolumeSourceValidator {
+  static void validate(KubernetesVolumeSource source, StandardKubernetesAttributeValidator helper, String prefix) {
+    helper.validateName(source.name, "${prefix}.name")
+    switch (source.type) {
+      case KubernetesVolumeSourceType.EMPTYDIR:
+        helper.validateNotEmpty(source.emptyDir, "${prefix}.emptyDir")
+
+        break // Nothing else to validate, only property is an enum which is implicitly validated during deserialization
+
+      case KubernetesVolumeSourceType.HOSTPATH:
+        if (!helper.validateNotEmpty(source.hostPath, "${prefix}.hostPath")) {
+          break
+        }
+        helper.validatePath(source.hostPath.path, "${prefix}.hostPath.path")
+
+        break
+
+      case KubernetesVolumeSourceType.PERSISTENTVOLUMECLAIM:
+        if (!helper.validateNotEmpty(source.persistentVolumeClaim, "${prefix}.persistentVolumeClaim")) {
+          break
+        }
+        helper.validateName(source.persistentVolumeClaim.claimName, "${prefix}.persistentVolumeClaim.claimName")
+
+        break
+
+      case KubernetesVolumeSourceType.SECRET:
+        if (!helper.validateNotEmpty(source.secret, "${prefix}.secret")) {
+          break
+        }
+        helper.validateName(source.secret.secretName, "${prefix}.secret.secretName")
+
+        break
+
+      default:
+        helper.reject("${prefix}.type", "$source.type not supported")
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidator.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergro
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.KubernetesContainerValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -76,7 +76,7 @@ public class KubernetesCredentials {
         secretBuilder = secretBuilder.withNewMetadata().withName(secretName).endMetadata();
 
         HashMap<String, String> secretData = new HashMap<>(1);
-        String dockerCfg = String.format("{ \"%s\": { \"auth\": \"%s\", \"email\": \"%s\" } }", account.getV2Endpoint(), account.getBasicAuth(), account.getEmail());
+        String dockerCfg = String.format("{ \"%s\": { \"auth\": \"%s\", \"email\": \"%s\" } }", account.getAddress(), account.getBasicAuth(), account.getEmail());
         try {
           dockerCfg = new String(Base64.getEncoder().encode(dockerCfg.getBytes("UTF-8")), "UTF-8");
         } catch (UnsupportedEncodingException uee) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup.KubernetesContainerValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.*

--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -1,6 +1,5 @@
 dependencies {
   compile project(":clouddriver-core")
-  compile project(":clouddriver-aws")
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
   compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProvider.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.titus.caching
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.provider.Provider
-import com.netflix.spinnaker.clouddriver.aws.provider.agent.HealthProvidingCachingAgent //TODO-Move health agent to common module
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 
 class TitusCachingProvider implements Provider {
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
@@ -46,6 +46,8 @@ public class JobDescription {
     private List<String> hardConstraints;
     private Map<String, String> labels;
 
+    private String entryPoint;
+
     //Soft/Hard constraints
 
     JobDescription() {}
@@ -77,6 +79,7 @@ public class JobDescription {
         user = request.getUser();
         env = request.getEnv() != null ? request.getEnv() : new HashMap<>();
         labels = request.getLabels() != null ? request.getLabels() : new HashMap<>();
+        entryPoint = request.getEntryPoint();
     }
 
     public String getName() {
@@ -243,4 +246,9 @@ public class JobDescription {
     public void setLabels(Map<String, String> labels) {
         this.labels = labels;
     }
+
+    public String getEntryPoint() { return entryPoint; }
+
+    public void setEntryPoint(String entryPoint) { this.entryPoint = entryPoint; }
+
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
@@ -62,6 +62,7 @@ public class SubmitJobRequest {
     private String stack;
     private String detail;
     private String user;
+    private String entryPoint;
     private int instancesMin;
     private int instancesMax;
     private int instancesDesired;
@@ -159,6 +160,12 @@ public class SubmitJobRequest {
         return this;
     }
 
+
+    public SubmitJobRequest withEntryPoint(String entryPoint) {
+      this.entryPoint = entryPoint;
+      return this;
+    }
+
     public SubmitJobRequest withConstraint(Constraint constraint) {
         this.constraints.add(constraint);
         return this;
@@ -243,6 +250,8 @@ public class SubmitJobRequest {
     public List<Constraint> getConstraints() {
         return constraints;
     }
+
+    public String getEntryPoint() { return entryPoint; }
 
     public Map<String, String> getLabels() {
         return labels;

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
@@ -31,6 +31,7 @@ class TitusDeployDescription extends AbstractTitusCredentialsDescription impleme
   Capacity capacity = new Capacity()
   Resources resources = new Resources()
   Map env
+  String entryPoint
 
   @Canonical
   static class Capacity {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -82,6 +82,7 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
         .withStack(description.stack)
         .withDetail(description.freeFormDetails)
         .withConstraint(SubmitJobRequest.Constraint.soft(SubmitJobRequest.Constraint.ZONE_BALANCE))
+        .withEntryPoint(description.entryPoint)
 
       task.updateStatus BASE_PHASE, "Submitting job request to Titus..."
       String jobUri = titusClient.submitJob(submitJobRequest)

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -58,7 +58,7 @@ class TitusInstance implements Instance {
     resources.cpu = job.cpu
     resources.memory = job.memory
     resources.disk = job.disk
-    resources.ports = job.ports.toList().collectEntries { [(it): it] }
+    resources.ports = job.ports ? job.ports.toList().collectEntries { [(it): it] } : [:]
 
     env = job.environment
     submittedAt = task.submittedAt ? task.submittedAt.time : null

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
@@ -35,6 +35,7 @@ class TitusServerGroup implements ServerGroup, Serializable {
   String id
   String name
   String type = TYPE
+  String entryPoint
   Map env
   Long submittedAt
   String application
@@ -52,6 +53,7 @@ class TitusServerGroup implements ServerGroup, Serializable {
     name = job.name
     image << [dockerImageName: job.applicationName]
     image << [dockerImageVersion: job.version]
+    entryPoint = job.entryPoint
     resources.cpu = job.cpu
     resources.memory = job.memory
     resources.disk = job.disk

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
@@ -58,6 +58,7 @@ class RegionScopedTitusClientSpec extends Specification {
       .withCpu(1)
       .withMemory(4096)
       .withDisk(2000)
+      .withEntryPoint("ls -la")
       .withPorts([7001] as int[])
       .withEnv(env)
       .withAllocateIpAddress(true);

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
@@ -23,28 +23,28 @@ import spock.lang.Specification
 
 class TitusInstanceSpec extends Specification {
 
+  Date launchDate = new Date()
+  Job job = new Job(
+    id: '1234',
+    name: 'api-test-v001',
+    applicationName: 'api.server',
+    version: 'v4321',
+    cpu: 1,
+    memory: 2000,
+    disk: 5000,
+    ports: [7150] as int[],
+    environment: [account: 'test', region: 'us-east-1'],
+  )
+  Job.TaskSummary task = new Job.TaskSummary(
+    id: '5678',
+    state: TaskState.RUNNING,
+    submittedAt: launchDate,
+    region: 'us-east-1',
+    host: 'ec2-1-2-3-4.compute-1.amazonaws.com',
+    data: [ipAddresses: [nfvpc: '4.5.6.7']]
+  )
+
   void 'valid titus instance is created from a titus task'() {
-    given:
-    Date launchDate = new Date()
-    Job job = new Job(
-      id: '1234',
-      name: 'api-test-v001',
-      applicationName: 'api.server',
-      version: 'v4321',
-      cpu: 1,
-      memory: 2000,
-      disk: 5000,
-      ports: [7150] as int[],
-      environment: [account: 'test', region: 'us-east-1'],
-    )
-    Job.TaskSummary task = new Job.TaskSummary(
-      id: '5678',
-      state: TaskState.RUNNING,
-      submittedAt: launchDate,
-      region: 'us-east-1',
-      host: 'ec2-1-2-3-4.compute-1.amazonaws.com',
-      data: [ ipAddresses : [ nfvpc : '4.5.6.7'] ]
-    )
 
     when:
     TitusInstance titusInstance = new TitusInstance(job, task)
@@ -66,8 +66,18 @@ class TitusInstanceSpec extends Specification {
     titusInstance.resources?.cpu == job.cpu
     titusInstance.resources?.memory == job.memory
     titusInstance.resources?.disk == job.disk
+    titusInstance.resources?.ports == [7150: 7150]
     titusInstance.env?.account == 'test'
     titusInstance.submittedAt == task.submittedAt.time
     titusInstance.finishedAt == null
   }
+
+  void 'can handle null ports'() {
+    when:
+    job.setPorts(null)
+    TitusInstance titusInstance = new TitusInstance(job, task)
+    then:
+    titusInstance.resources.ports == [:]
+  }
+
 }

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroupSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroupSpec.groovy
@@ -22,32 +22,32 @@ import spock.lang.Specification
 
 class TitusServerGroupSpec extends Specification {
 
-  void 'valid server group instance is created from a titus job'() {
-    given:
-    Date launchDate = new Date()
-    Job job = new Job(
-      id: '1234',
-      name: 'api-test-v000',
-      applicationName: 'api.server',
-      version: 'v4321',
-      cpu: 1,
-      memory: 2000,
-      disk: 5000,
-      ports: [8080],
-      instances: 2,
-      instancesMin: 1,
-      instancesMax: 10,
-      instancesDesired: 5,
-      environment: [account: 'test'],
+  Date launchDate = new Date()
+  Job job = new Job(
+    id: '1234',
+    name: 'api-test-v000',
+    applicationName: 'api.server',
+    version: 'v4321',
+    cpu: 1,
+    memory: 2000,
+    disk: 5000,
+    ports: [8080],
+    instances: 2,
+    instancesMin: 1,
+    instancesMax: 10,
+    instancesDesired: 5,
+    environment: [account: 'test'],
+    submittedAt: launchDate,
+    tasks: [new Job.TaskSummary(
+      id: '5678',
+      region: 'us-east-1',
+      state: TaskState.RUNNING,
       submittedAt: launchDate,
-      tasks: [new Job.TaskSummary(
-        id: '5678',
-        region: 'us-east-1',
-        state: TaskState.RUNNING,
-        submittedAt: launchDate,
-        host: 'ec2-1-2-3-4.compute-1.amazonaws.com'
-      )]
-    )
+      host: 'ec2-1-2-3-4.compute-1.amazonaws.com'
+    )]
+  )
+
+  void 'valid server group instance is created from a titus job'() {
 
     when:
     TitusServerGroup titusServerGroup = new TitusServerGroup(job)
@@ -74,5 +74,14 @@ class TitusServerGroupSpec extends Specification {
     titusServerGroup.capacity?.min == job.instancesMin
     titusServerGroup.capacity?.max == job.instancesMax
     titusServerGroup.capacity?.desired == job.instancesDesired
+  }
+
+  void 'can handle empty ports'(){
+    when:
+    job.setPorts(null)
+    TitusServerGroup titusServerGroup = new TitusServerGroup(job)
+
+    then:
+    titusServerGroup.resources.ports == []
   }
 }


### PR DESCRIPTION
Add destroy server group ops. This payload was reviewed previously; the only addition is the test and removing some commented out lines in the validation class.
Add type for the deployment. Updating the python tests to reflect these changes is a separate task.
Cleanup resources that are created as part of the create server group in case of a failure during the creation.
Add retries support when deleting a resource in Azure (work around for random timeouts).
Fix an assertion in clouddriver console when the application has no clusters.

@JargoonPard @scotmoor PTAL; I'm looking to submit A PR with these changes later tonight.
